### PR TITLE
Feat(Bus): Implement Get Single Bus

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,17 @@
+exclude_patterns:
+- "build/"
+- "server/tests/"
+- "UI/**/*"
+checks:
+  return-statements:
+    enabled: false
+  similar-code:
+    enabled: false
+  identical-code:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-lines:
+    enabled: false
+  method-complexity:
+    enabled: false

--- a/src/controllers/busController.js
+++ b/src/controllers/busController.js
@@ -1,7 +1,11 @@
 import busModel from '../models/busModel';
 import HelperUtils from '../helperUtils/helperUtils';
 
-const { createBus, getAllBuses } = busModel;
+const {
+  createBus,
+  getAllBuses,
+  getSingleBus,
+} = busModel;
 
 class busController {
   static async createNewBus({ body }, res) {
@@ -12,6 +16,11 @@ class busController {
   static async fetchAllBuses(req, res) {
     const response = await getAllBuses();
     return HelperUtils.serverResponse(response, res, 200, 'buses');
+  }
+  
+  static async fetchSingleBus({ params }, res) {
+    const [response] = await getSingleBus(params);
+    return HelperUtils.serverResponse(response, res);
   }
 }
 

--- a/src/models/busModel.js
+++ b/src/models/busModel.js
@@ -13,6 +13,11 @@ const busModel = {
     const sql = 'SELECT * FROM buses';
     return query(sql);
   },
+  
+  async getSingleBus({ busId }) {
+    const sql = 'SELECT * FROM buses WHERE bus_id = $1';
+    return query(sql, [busId]);
+  },
 };
 
 export default busModel;

--- a/src/routes/busRoutes.js
+++ b/src/routes/busRoutes.js
@@ -11,4 +11,7 @@ export default (server) => {
       ValidateData.validateBusData,
       busController.createNewBus,
     );
+    
+  server.route('/api/v1/buses/:busId')
+    .get(Authenticate.verifyToken, Authenticate.isAdmin, busController.fetchSingleBus);
 };

--- a/src/tests/bus.spec.js
+++ b/src/tests/bus.spec.js
@@ -96,4 +96,19 @@ describe('Bus Routes', () => {
       }
     });
   });
+  
+  describe('Fetch a particular bus', () => {
+    it('should fetch a specific bus from the database', async () => {
+      try {
+        const result = await chai
+          .request(app)
+          .get(`${allBuses}/${busId}`)
+          .set('x-access-token', token);
+        result.should.have.status(200);
+        result.body.should.have.property('data');
+      } catch (error) {
+        throw new Error(error);
+      }
+    });
+  });
 });


### PR DESCRIPTION
#What does this PR do?
This PR implements the get single bus functionality of the bus entity

#What major tasks were carried out to achieve it?
- [ ] Write tests to test get single bus endpoint and run them to fail
- [ ] Write route functions to handle the requests from the server
- [ ] Write controller function to handle the business logic of getting a specific bus
- [ ] Update the middleware functions to handle input validations and sanitization
- [ ] Run test again and refactor code for elegance and speed

#How do we test this feature?
1. Clone repository by running `git clone https://github.com/darasimiolaifa/Way-Farer.git`
2. `cd` into the project folder
3. Run `npm install` to install all libraries and dependencies
4. Run `npm run dev` to start server
5. Launch Postman to help you test the endpoint
6. Enter `localhost:3000/api/v1/auth/signin` into the address bar
7. In the request space, send the following data to the endpoint
   - `email: 'dakoloz@wayfarer.com'`
   - `password: 'yppZgpjXNl61GvMmgzeV5'`
8. Get the token sent by this endpoint. (Admin User)
9. Enter `localhost:3000/api/v1/buses/:busId`, substituting `busId` with the bus' id you want to view into the address bar setting the token in the header section using `x-access-token` as your key
10. Make sure your HTTP verb is set to `get`. Then send.

PT Story Link: [167217779](https://www.pivotaltracker.com/story/show/167217779)