### PR TITLE
Feat(Trip): Implement Edit Trip

### DIFF
--- a/src/controllers/tripController.js
+++ b/src/controllers/tripController.js
@@ -6,6 +6,7 @@ const {
   getAllTrips,
   getSingleTrip,
   updateTrip,
+  updateTripStatus,
 } = tripModel;
 
 class tripController {
@@ -28,6 +29,11 @@ class tripController {
   static async updateOldTrip({ body }, res) {
     const [response] = await updateTrip(body);
     return HelperUtils.serverResponse(response, res, 200, 'Trip', 'updated');
+  }
+  
+  static async updateOldTripStatus({ params }, res) {
+    const [response] = await updateTripStatus(params);
+    return HelperUtils.serverResponse(response, res, 200, 'Trip', 'cancelled');
   }
 }
 

--- a/src/controllers/tripController.js
+++ b/src/controllers/tripController.js
@@ -5,6 +5,7 @@ const {
   createTrip,
   getAllTrips,
   getSingleTrip,
+  updateTrip,
 } = tripModel;
 
 class tripController {
@@ -22,6 +23,11 @@ class tripController {
   static async fetchSingleTrip({ params }, res) {
     const [response] = await getSingleTrip(params);
     return HelperUtils.serverResponse(response, res);
+  }
+  
+  static async updateOldTrip({ body }, res) {
+    const [response] = await updateTrip(body);
+    return HelperUtils.serverResponse(response, res, 200, 'Trip', 'updated');
   }
 }
 

--- a/src/helperUtils/helperUtils.js
+++ b/src/helperUtils/helperUtils.js
@@ -65,8 +65,8 @@ class HelperUtils {
     return camelCasedArray.join('');
   }
   
-  static buildUpdateData(model, body, res, next) {
-    if (!model) return res.status(404).send({ status: 404, error: `${model} does not exist.` });
+  static buildUpdateData(model, resource, body, res, next) {
+    if (!model) return res.status(404).send({ status: 404, error: `${resource} does not exist.` });
     const fields = Object.keys(model);
     fields.forEach((element) => {
       const field = HelperUtils.transformToCamelCase(element);

--- a/src/middleware/buildUpdateData.js
+++ b/src/middleware/buildUpdateData.js
@@ -1,19 +1,26 @@
 /* eslint-disable no-param-reassign */
 import userModel from '../models/userModel';
 import busModel from '../models/busModel';
+import tripModel from '../models/tripModel';
 import HelperUtils from '../helperUtils/helperUtils';
 
 class BuildUpdateData {
   static async userData({ params, body }, res, next) {
     const { getSingleUser } = userModel;
     const [user] = await getSingleUser('user_id', params.userId);
-    return HelperUtils.buildUpdateData(user, body, res, next);
+    return HelperUtils.buildUpdateData(user, 'User', body, res, next);
   }
   
   static async busData({ params, body }, res, next) {
     const { getSingleBus } = busModel;
     const [bus] = await getSingleBus(params);
-    return HelperUtils.buildUpdateData(bus, body, res, next);
+    return HelperUtils.buildUpdateData(bus, 'Bus', body, res, next);
+  }
+  
+  static async tripData({ params, body }, res, next) {
+    const { getSingleTrip } = tripModel;
+    const [trip] = await getSingleTrip(params);
+    return HelperUtils.buildUpdateData(trip, 'Trip', body, res, next);
   }
 }
 

--- a/src/models/tripModel.js
+++ b/src/models/tripModel.js
@@ -20,6 +20,13 @@ const tripModel = {
     
     return query(sql, [tripId]);
   },
+  
+  async updateTrip({
+    tripId, busId, origin, destination, fare, tripDate,
+  }) {
+    const sql = 'UPDATE trips SET bus_id = $1, origin = $2, destination = $3, fare = $4, trip_date = $5 WHERE trip_id = $6 RETURNING *';
+    return query(sql, [busId, origin, destination, fare, tripDate, tripId]);
+  },
 };
 
 export default tripModel;

--- a/src/models/tripModel.js
+++ b/src/models/tripModel.js
@@ -27,6 +27,11 @@ const tripModel = {
     const sql = 'UPDATE trips SET bus_id = $1, origin = $2, destination = $3, fare = $4, trip_date = $5 WHERE trip_id = $6 RETURNING *';
     return query(sql, [busId, origin, destination, fare, tripDate, tripId]);
   },
+  
+  async updateTripStatus({ tripId }) {
+    const sql = 'UPDATE trips SET status = $1 WHERE trip_id = $2 RETURNING *';
+    return query(sql, ['cancelled', tripId]);
+  },
 };
 
 export default tripModel;

--- a/src/routes/tripRoutes.js
+++ b/src/routes/tripRoutes.js
@@ -14,7 +14,8 @@ export default (server) => {
     );
   
   server.route('/api/v1/trips/:tripId')
-    .get(Authenticate.verifyToken, tripController.fetchSingleTrip);
+    .get(Authenticate.verifyToken, tripController.fetchSingleTrip)
+    .patch(Authenticate.verifyToken, Authenticate.isAdmin, tripController.updateOldTripStatus);
     
   server.route('/api/v1/trips/:tripId/edit')
     .patch(

--- a/src/routes/tripRoutes.js
+++ b/src/routes/tripRoutes.js
@@ -1,6 +1,7 @@
 import tripController from '../controllers/tripController';
 import Authenticate from '../middleware/authenticator';
 import ValidateData from '../middleware/validateInputData';
+import BuildUpdateData from '../middleware/buildUpdateData';
 
 export default (server) => {
   server.route('/api/v1/trips')
@@ -14,4 +15,13 @@ export default (server) => {
   
   server.route('/api/v1/trips/:tripId')
     .get(Authenticate.verifyToken, tripController.fetchSingleTrip);
+    
+  server.route('/api/v1/trips/:tripId/edit')
+    .patch(
+      Authenticate.verifyToken,
+      Authenticate.isAdmin,
+      BuildUpdateData.tripData,
+      ValidateData.validateTripData,
+      tripController.updateOldTrip,
+    );
 };

--- a/src/tests/trip.spec.js
+++ b/src/tests/trip.spec.js
@@ -107,4 +107,23 @@ describe('Trips Routes', () => {
       }
     });
   });
+  
+  describe('Update a particular trip', () => {
+    it('should update a specific trip record', async () => {
+      try {
+        const result = await chai
+          .request(app)
+          .patch(`${allTrips}/${tripId}/edit`)
+          .set('x-access-token', token)
+          .send({
+            tripDate: faker.date.future(),
+            fare: faker.finance.amount(),
+          });
+        result.should.have.status(200);
+        result.body.should.have.property('data');
+      } catch (error) {
+        throw new Error(error);
+      }
+    });
+  });
 });

--- a/src/tests/trip.spec.js
+++ b/src/tests/trip.spec.js
@@ -126,4 +126,19 @@ describe('Trips Routes', () => {
       }
     });
   });
+  
+  describe('Cancel trip', () => {
+    it('should change the status of a trip to cancelled', async () => {
+      try {
+        const result = await chai
+          .request(app)
+          .patch(`${allTrips}/${tripId}`)
+          .set('x-access-token', token);
+        result.should.have.status(200);
+        result.body.should.have.property('data');
+      } catch (error) {
+        throw new Error(error);
+      }
+    });
+  });
 });


### PR DESCRIPTION
#What does this PR do?
This PR implements the edit trip functionality of the trip entity

#What major tasks were carried out to achieve it?

- [ ] Write tests to test edit trip endpoint and run them to fail
- [ ] Write route functions to handle the requests from the server
- [ ] Write controller function to handle the business logic of editing the trip details
- [ ] Update the middleware functions to handle input validations and sanitization
- [ ] Run test again and refactor code for elegance and speed

#How do we test this feature?

1. Clone repository by running `git clone https://github.com/darasimiolaifa/Way-Farer.git`
2. `cd` into the project folder
3. Run `npm install` to install all libraries and dependencies
4. Run `npm run dev` to start server
5. Launch Postman to help you test the endpoint
6. Enter `localhost:3000/api/v1/auth/signin` into the address bar
7. In the request space, send the following data to the endpoint
   - `email: 'dakoloz@wayfarer.com'`
   - `password: 'yppZgpjXNl61GvMmgzeV5'`
8. Get the token sent by this endpoint. (Admin User)
9. Enter `localhost:3000/api/v1/trips/:tripId/edit` into the address bar setting the token in the header section using `x-access-token` as your key
10. Then in the request pane, enter any combination of the following details to edit the particular trip:
      - `origin (type: String)`
      - `destination (type: String)`
      - `tripDate (type: Date)`
      - `busID (type: Integer) must obey foreign key constraints with buses table`
      - `fare (type: float)`
      - `status (type: String) either of 'cancelled' or 'active'. 'active' by default`
10. To cancel specifically, enter `localhost:3000/api/v1/trips/:tripId` instead, and don't supply any details in the request pane, except for setting the token in the header
11. Make sure your HTTP verb is set to `patch`, then send.

PT Story Link: [167217736](https://www.pivotaltracker.com/story/show/167217736)