### PR TITLE
Feat(Trip): Implement Delete Trip

### DIFF
--- a/src/controllers/tripController.js
+++ b/src/controllers/tripController.js
@@ -7,6 +7,7 @@ const {
   getSingleTrip,
   updateTrip,
   updateTripStatus,
+  deleteTrip,
 } = tripModel;
 
 class tripController {
@@ -34,6 +35,11 @@ class tripController {
   static async updateOldTripStatus({ params }, res) {
     const [response] = await updateTripStatus(params);
     return HelperUtils.serverResponse(response, res, 200, 'Trip', 'cancelled');
+  }
+  
+  static async deleteOldTrip({ params }, res) {
+    const [response] = await deleteTrip(params);
+    return HelperUtils.serverResponse(response, res, 200, 'Trip', 'deleted');
   }
 }
 

--- a/src/models/tripModel.js
+++ b/src/models/tripModel.js
@@ -32,6 +32,11 @@ const tripModel = {
     const sql = 'UPDATE trips SET status = $1 WHERE trip_id = $2 RETURNING *';
     return query(sql, ['cancelled', tripId]);
   },
+  
+  async deleteTrip({ tripId }) {
+    const sql = 'DELETE FROM trips WHERE trip_id = $1 RETURNING *';
+    return query(sql, [tripId]);
+  },
 };
 
 export default tripModel;

--- a/src/routes/tripRoutes.js
+++ b/src/routes/tripRoutes.js
@@ -15,7 +15,8 @@ export default (server) => {
   
   server.route('/api/v1/trips/:tripId')
     .get(Authenticate.verifyToken, tripController.fetchSingleTrip)
-    .patch(Authenticate.verifyToken, Authenticate.isAdmin, tripController.updateOldTripStatus);
+    .patch(Authenticate.verifyToken, Authenticate.isAdmin, tripController.updateOldTripStatus)
+    .delete(Authenticate.verifyToken, Authenticate.isAdmin, tripController.deleteOldTrip);
     
   server.route('/api/v1/trips/:tripId/edit')
     .patch(

--- a/src/tests/trip.spec.js
+++ b/src/tests/trip.spec.js
@@ -141,4 +141,19 @@ describe('Trips Routes', () => {
       }
     });
   });
+  
+  describe('Delete a particular trip', () => {
+    it('should delete a specific trip record', async () => {
+      try {
+        const result = await chai
+          .request(app)
+          .delete(`${allTrips}/${tripId}`)
+          .set('x-access-token', token);
+        result.should.have.status(200);
+        result.body.should.have.property('data');
+      } catch (error) {
+        throw new Error(error);
+      }
+    });
+  });
 });


### PR DESCRIPTION
#What does this PR do?
This PR implements the delete trip functionality of the trip entity

#What major tasks were carried out to achieve it?

- [ ] Write tests to test delete trip endpoint and run them to fail
- [ ] Write route functions to handle the requests from the server
- [ ] Write controller function to handle the business logic of deleting the trip details from the database
- [ ] Update the middleware functions to handle input validations and sanitization
- [ ] Run test again and refactor code for elegance and speed

#How do we test this feature?

1. Clone repository by running `git clone https://github.com/darasimiolaifa/Way-Farer.git`
2. `cd` into the project folder
3. Run `npm install` to install all libraries and dependencies
4. Run `npm run dev` to start server
5. Launch Postman to help you test the endpoint
6. Enter `localhost:3000/api/v1/auth/signin` into the address bar
7. In the request space, send the following data to the endpoint
   - `email: 'dakoloz@wayfarer.com'`
   - `password: 'yppZgpjXNl61GvMmgzeV5'`
8. Get the token sent by this endpoint. (Admin User)
9. Enter `localhost:3000/api/v1/trips/:tripId` into the address bar setting the token in the header section using `x-access-token` as your key, and subsituting `:tripId` with the id of the trip to delete.
10. Make sure your HTTP verb is set to `delete`. Then send.

PT Story Link: [167217752](https://www.pivotaltracker.com/story/show/167217752)